### PR TITLE
Add autocomplete attribute to some password fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ At the time of writing I am not sure if all Members events support redirects, so
 
 You should keep in mind that POST values will not "survive" a redirect. So they will not show up in the target page's event XML.
 
+### Turning "autocomplete" off for Inputs
+
+When calling the `members:input`, `members:input-password` and `members:password-input-confirm` templates you can pass a parameter named `autocomplete` with a value of `off` to turn the browser's auto-completion off. This may be especially useful for password fields in a member's edit account form to stop a previously-saved password from being automatically inserted. For example:
+
+	<xsl:call-template name="members:input-password">
+		<xsl:with-param name="event" select="$event"/>
+		<xsl:with-param name="mode" select="'edit'"/>
+		<xsl:with-param name="autocomplete" select="'off'"/>
+	</xsl:call-template>
 
 ## Namespace
 

--- a/members.forms.xsl
+++ b/members.forms.xsl
@@ -27,6 +27,7 @@
 	<xsl:param name="id"/>
 	<xsl:param name="name" select="concat('fields[', $field-handle, ']')"/>
 	<xsl:param name="xml-post-value" select="/data/events/*[name()=$event]/post-values/*[name()=$field-handle]"/>
+	<xsl:param name="autocomplete" select="'on'"/>
 	<xsl:variable name="final-id">
 		<xsl:choose>
 			<xsl:when test="$id != ''">
@@ -53,7 +54,7 @@
 			</xsl:if>
 			<xsl:copy-of select="$field-label/*|$field-label/text()"/>
 		</label>
-		<input type="{$type}" id="{$final-id}" name="{$name}">
+		<input type="{$type}" id="{$final-id}" name="{$name}" autocomplete="{$autocomplete}">
 			<xsl:if test="$invalid">
 				<xsl:attribute name="class">
 					<xsl:value-of select="$members:invalid-class"/>
@@ -102,6 +103,7 @@
 					<xsl:with-param name="field-label" select="$members:config/data/fields/field[@type='password']/label/*[name()=$mode]"/>
 					<xsl:with-param name="field-handle" select="concat($members:config/data/fields/field[@type='password']/@handle, '-password')"/>
 					<xsl:with-param name="name" select="concat('fields[', $members:config/data/fields/field[@type='password']/@handle, '][password]')"/>
+					<xsl:with-param name="autocomplete" select="'off'"/>
 					<xsl:with-param name="xml-post-value">
 						<xsl:if test="$members:use-password-postback">
 							<xsl:value-of select="/data/events/*[name()=$event]/post-values/*[name()=$members:config/data/fields/field[@type='password']/@handle]/password"/>
@@ -126,6 +128,7 @@
 		<xsl:with-param name="field-label" select="$members:config/data/fields/field[@type='password-confirm']/label/*[name()=$mode]"/>
 		<xsl:with-param name="field-handle" select="concat($members:config/data/fields/field[@type='password']/@handle, '-confirm')"/>
 		<xsl:with-param name="name" select="concat('fields[', $members:config/data/fields/field[@type='password']/@handle, '][confirm]')"/>
+		<xsl:with-param name="autocomplete" select="'off'"/>
 		<xsl:with-param name="xml-post-value">
 			<xsl:if test="$members:use-password-postback">
 				<xsl:value-of select="/data/events/*[name()=$event]/post-values/*[name()=$members:config/data/fields/field[@type='password']/@handle]/confirm"/>

--- a/members.forms.xsl
+++ b/members.forms.xsl
@@ -55,7 +55,7 @@
 			<xsl:copy-of select="$field-label/*|$field-label/text()"/>
 		</label>
 		<input type="{$type}" id="{$final-id}" name="{$name}">
-			<xsl:if test="$autocomplete">
+			<xsl:if test="$autocomplete != ''">
 				<xsl:attribute name="autocomplete">
 					<xsl:value-of select="$autocomplete"/>
 				</xsl:attribute>
@@ -82,6 +82,7 @@
 	<xsl:param name="value"/>
 	<xsl:param name="id"/>
 	<xsl:param name="mode"/>
+	<xsl:param name="autocomplete"/>
 		<xsl:choose>
 			<xsl:when test="$mode='login'">
 				<xsl:call-template name="members:input">
@@ -91,6 +92,11 @@
 					<xsl:with-param name="id" select="$id"/>
 					<xsl:with-param name="field" select="'password'"/>
 					<xsl:with-param name="field-label" select="$members:config/data/fields/field[@type='password']/label/login"/>
+					<xsl:with-param name="autocomplete">
+						<xsl:if test="$autocomplete != ''">
+							<xsl:value-of select="$autocomplete"/>
+						</xsl:if>
+					</xsl:with-param>
 					<xsl:with-param name="xml-post-value">
 						<xsl:if test="$members:use-password-postback">
 							<xsl:value-of select="/data/events/*[name()=$event]/post-values/*[name()=$members:config/data/fields/field[@type='password']/@handle]"/>
@@ -108,7 +114,11 @@
 					<xsl:with-param name="field-label" select="$members:config/data/fields/field[@type='password']/label/*[name()=$mode]"/>
 					<xsl:with-param name="field-handle" select="concat($members:config/data/fields/field[@type='password']/@handle, '-password')"/>
 					<xsl:with-param name="name" select="concat('fields[', $members:config/data/fields/field[@type='password']/@handle, '][password]')"/>
-					<xsl:with-param name="autocomplete" select="'off'"/>
+					<xsl:with-param name="autocomplete">
+						<xsl:if test="$autocomplete != ''">
+							<xsl:value-of select="$autocomplete"/>
+						</xsl:if>
+					</xsl:with-param>
 					<xsl:with-param name="xml-post-value">
 						<xsl:if test="$members:use-password-postback">
 							<xsl:value-of select="/data/events/*[name()=$event]/post-values/*[name()=$members:config/data/fields/field[@type='password']/@handle]/password"/>
@@ -124,6 +134,7 @@
 	<xsl:param name="value"/>
 	<xsl:param name="id"/>
 	<xsl:param name="mode"/>
+	<xsl:param name="autocomplete"/>
 	<xsl:call-template name="members:input">
 		<xsl:with-param name="type" select="'password'"/>
 		<xsl:with-param name="event" select="$event"/>
@@ -133,7 +144,11 @@
 		<xsl:with-param name="field-label" select="$members:config/data/fields/field[@type='password-confirm']/label/*[name()=$mode]"/>
 		<xsl:with-param name="field-handle" select="concat($members:config/data/fields/field[@type='password']/@handle, '-confirm')"/>
 		<xsl:with-param name="name" select="concat('fields[', $members:config/data/fields/field[@type='password']/@handle, '][confirm]')"/>
-		<xsl:with-param name="autocomplete" select="'off'"/>
+		<xsl:with-param name="autocomplete">
+			<xsl:if test="$autocomplete != ''">
+				<xsl:value-of select="$autocomplete"/>
+			</xsl:if>
+		</xsl:with-param>
 		<xsl:with-param name="xml-post-value">
 			<xsl:if test="$members:use-password-postback">
 				<xsl:value-of select="/data/events/*[name()=$event]/post-values/*[name()=$members:config/data/fields/field[@type='password']/@handle]/confirm"/>

--- a/members.forms.xsl
+++ b/members.forms.xsl
@@ -27,7 +27,7 @@
 	<xsl:param name="id"/>
 	<xsl:param name="name" select="concat('fields[', $field-handle, ']')"/>
 	<xsl:param name="xml-post-value" select="/data/events/*[name()=$event]/post-values/*[name()=$field-handle]"/>
-	<xsl:param name="autocomplete" select="'on'"/>
+	<xsl:param name="autocomplete"/>
 	<xsl:variable name="final-id">
 		<xsl:choose>
 			<xsl:when test="$id != ''">
@@ -54,7 +54,12 @@
 			</xsl:if>
 			<xsl:copy-of select="$field-label/*|$field-label/text()"/>
 		</label>
-		<input type="{$type}" id="{$final-id}" name="{$name}" autocomplete="{$autocomplete}">
+		<input type="{$type}" id="{$final-id}" name="{$name}">
+			<xsl:if test="$autocomplete">
+				<xsl:attribute name="autocomplete">
+					<xsl:value-of select="$autocomplete"/>
+				</xsl:attribute>
+			</xsl:if>
 			<xsl:if test="$invalid">
 				<xsl:attribute name="class">
 					<xsl:value-of select="$members:invalid-class"/>


### PR DESCRIPTION
I was finding that my browser was auto-completing the first password field on my edit member account page, resulting in a password match failure if the password fields were left as is.

To prevent that, this commit sets the `autocomplete` attribute to `off` when `$mode` is not `login`. (The login form's password field has `autocomplete` set to `on`, meaning a member's browser can still pre-fill it if they have chosen to save their password.)
